### PR TITLE
feat: implementa cadastro de edital

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -8,7 +8,7 @@
       </list>
     </option>
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_26" default="true" project-jdk-name="openjdk-26" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/out" />
   </component>
 </project>

--- a/feature1.1.iml
+++ b/feature1.1.iml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<module type="JAVA_MODULE" version="4">
+  <component name="NewModuleRootManager" inherit-compiler-output="true">
+    <exclude-output />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/src" isTestSource="false" />
+    </content>
+    <orderEntry type="inheritedJdk" />
+    <orderEntry type="sourceFolder" forTests="false" />
+  </component>
+</module>

--- a/src/main/java/br/ifpe/proext/controller/EditalController.java
+++ b/src/main/java/br/ifpe/proext/controller/EditalController.java
@@ -1,9 +1,8 @@
 package br.ifpe.proext.controller;
 
 import br.ifpe.proext.model.Edital;
-import br.ifpe.proext.model.Servidor;
 import br.ifpe.proext.service.EditalService;
-import br.ifpe.proext.service.ServidorService;
+
 
 public class EditalController {
 

--- a/src/main/java/br/ifpe/proext/controller/EditalController.java
+++ b/src/main/java/br/ifpe/proext/controller/EditalController.java
@@ -1,0 +1,21 @@
+package br.ifpe.proext.controller;
+
+import br.ifpe.proext.model.Edital;
+import br.ifpe.proext.model.Servidor;
+import br.ifpe.proext.service.EditalService;
+import br.ifpe.proext.service.ServidorService;
+
+public class EditalController {
+
+    private EditalController(){}
+
+    public static void cadastrarEdital(Edital edital){
+
+        try {
+            EditalService.cadastrarEdital(edital);
+        } catch (RuntimeException e) {
+            System.out.println(e.getMessage());
+        }
+    }
+
+}

--- a/src/main/java/br/ifpe/proext/model/Edital.java
+++ b/src/main/java/br/ifpe/proext/model/Edital.java
@@ -1,14 +1,22 @@
 package br.ifpe.proext.model;
 
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.Date;
+
 public class Edital {
 
+    private static final String FORMATO_DATA = "dd/MM/yyyy";
     private String titulo;
-    private String numero;
-    private String data;
-    private String inicioSumbissao;
-    private String fimSumbissao;
-    private String inicioAvaliacao;
-    private String fimAvaliacao;
+    private int numero;
+    private int ano;
+    private long data;
+    private long inicioSubmissao;
+    private long fimSubmissao;
+    private long inicioAvaliacao;
+    private long fimAvaliacao;
+
+    public Edital() {}
 
     public String getTitulo() {
         return titulo;
@@ -18,55 +26,115 @@ public class Edital {
         this.titulo = titulo;
     }
 
-    public String getNumero() {
+    public int getNumero() {
         return numero;
     }
 
-    public void setNumero(String numero) {
-        this.numero = numero;
+    public int getAno() {
+        return ano;
     }
 
-    public String getData() {
+    public void setAno(int ano) {
+        this.ano = ano;
+    }
+
+    public long getData() {
         return data;
     }
 
-    public void setData(String data) {
+    public void setData(long data) {
         this.data = data;
     }
-
-    public String getInicioSumbissao() {
-        return inicioSumbissao;
+    public long getInicioSubmissao() {
+        return inicioSubmissao;
     }
 
-    public void setInicioSumbissao(String inicioSumbissao) {
-        this.inicioSumbissao = inicioSumbissao;
+    public void setInicioSubmissao(long inicioSubmissao) {
+        this.inicioSubmissao = inicioSubmissao;
     }
 
-    public String getFimSumbissao() {
-        return fimSumbissao;
+    public void setInicioSubmissao(String data)
+            throws ParseException {
+
+        this.inicioSubmissao =
+                new SimpleDateFormat(FORMATO_DATA)
+                        .parse(data)
+                        .getTime();
     }
 
-    public void setFimSumbissao(String fimSumbissao) {
-        this.fimSumbissao = fimSumbissao;
+    public String getInicioSubmissaoString() {
+
+        return new SimpleDateFormat(FORMATO_DATA)
+                .format(new Date(this.inicioSubmissao));
+    }
+    public long getFimSubmissao() {
+        return fimSubmissao;
     }
 
-    public String getInicioAvaliacao() {
+    public void setFimSubmissao(long fimSubmissao) {
+        this.fimSubmissao = fimSubmissao;
+    }
+
+    public void setFimSubmissao(String data)
+            throws ParseException {
+
+        this.fimSubmissao =
+                new SimpleDateFormat(FORMATO_DATA)
+                        .parse(data)
+                        .getTime();
+    }
+
+    public String getFimSubmissaoString() {
+
+        return new SimpleDateFormat(FORMATO_DATA)
+                .format(new Date(this.fimSubmissao));
+    }
+    public long getInicioAvaliacao() {
         return inicioAvaliacao;
     }
 
-    public void setInicioAvaliacao(String inicioAvaliacao) {
+    public void setInicioAvaliacao(long inicioAvaliacao) {
         this.inicioAvaliacao = inicioAvaliacao;
     }
 
-    public String getFimAvaliacao() {
+    public void setInicioAvaliacao(String data)
+            throws ParseException {
+
+        this.inicioAvaliacao =
+                new SimpleDateFormat(FORMATO_DATA)
+                        .parse(data)
+                        .getTime();
+    }
+
+    public String getInicioAvaliacaoString() {
+
+        return new SimpleDateFormat(FORMATO_DATA)
+                .format(new Date(this.inicioAvaliacao));
+    }
+
+    public long getFimAvaliacao() {
         return fimAvaliacao;
     }
 
-    public void setFimAvaliacao(String fimAvaliacao) {
+    public void setFimAvaliacao(long fimAvaliacao) {
         this.fimAvaliacao = fimAvaliacao;
     }
 
-    public Edital() {
+    public void setFimAvaliacao(String data)
+            throws ParseException {
+
+        this.fimAvaliacao =
+                new SimpleDateFormat(FORMATO_DATA)
+                        .parse(data)
+                        .getTime();
     }
 
+    public String getFimAvaliacaoString() {
+
+        return new SimpleDateFormat(FORMATO_DATA)
+                .format(new Date(this.fimAvaliacao));
+    }
+    public String getNumeroFormatado() {
+        return String.format("%02d/%d", numero, ano);
+    }
 }

--- a/src/main/java/br/ifpe/proext/model/Edital.java
+++ b/src/main/java/br/ifpe/proext/model/Edital.java
@@ -1,0 +1,72 @@
+package br.ifpe.proext.model;
+
+public class Edital {
+
+    private String titulo;
+    private String numero;
+    private String data;
+    private String inicioSumbissao;
+    private String fimSumbissao;
+    private String inicioAvaliacao;
+    private String fimAvaliacao;
+
+    public String getTitulo() {
+        return titulo;
+    }
+
+    public void setTitulo(String titulo) {
+        this.titulo = titulo;
+    }
+
+    public String getNumero() {
+        return numero;
+    }
+
+    public void setNumero(String numero) {
+        this.numero = numero;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
+
+    public String getInicioSumbissao() {
+        return inicioSumbissao;
+    }
+
+    public void setInicioSumbissao(String inicioSumbissao) {
+        this.inicioSumbissao = inicioSumbissao;
+    }
+
+    public String getFimSumbissao() {
+        return fimSumbissao;
+    }
+
+    public void setFimSumbissao(String fimSumbissao) {
+        this.fimSumbissao = fimSumbissao;
+    }
+
+    public String getInicioAvaliacao() {
+        return inicioAvaliacao;
+    }
+
+    public void setInicioAvaliacao(String inicioAvaliacao) {
+        this.inicioAvaliacao = inicioAvaliacao;
+    }
+
+    public String getFimAvaliacao() {
+        return fimAvaliacao;
+    }
+
+    public void setFimAvaliacao(String fimAvaliacao) {
+        this.fimAvaliacao = fimAvaliacao;
+    }
+
+    public Edital() {
+    }
+
+}

--- a/src/main/java/br/ifpe/proext/repository/EditalRepository.java
+++ b/src/main/java/br/ifpe/proext/repository/EditalRepository.java
@@ -17,21 +17,13 @@ public class EditalRepository {
         editais.add(edital);
     }
 
-    public static Edital buscarPorNumero(String numero){
-        for (Edital edital: editais) {
-            if(edital.getNumero().equals(numero)){
-                return edital;
-            }
-        }
-        return null;
-    }
 
     public static List<Edital> buscarPorTitulo(String titulo) {
 
         List<Edital> resultado = new ArrayList<>();
 
         for (Edital edital : editais) {
-            if (edital.getTitulo().equals(titulo)) {
+            if (edital.getTitulo().trim().toLowerCase().equals((titulo).trim().toLowerCase())) {
                 resultado.add(edital);
             }
         }
@@ -39,16 +31,32 @@ public class EditalRepository {
         return resultado;
     }
 
+    public static Edital buscarPorNumeroEAno(
+            int numero,
+            int ano) {
+
+        for (Edital edital : editais) {
+
+            if (edital.getNumero() == numero
+                    && edital.getAno() == ano) {
+
+                return edital;
+            }
+        }
+
+        return null;
+    }
+
     public static void atualizarEdital(Edital edital) {
 
         for (Edital editalAux : editais) {
 
-            if (editalAux.getNumero().equals(edital.getNumero())) {
+            if (editalAux.getNumero() == edital.getNumero()
+                    && editalAux.getAno() == edital.getAno()) {
 
                 editalAux.setTitulo(edital.getTitulo());
-                editalAux.setData(edital.getData());
-                editalAux.setInicioSumbissao(edital.getInicioSumbissao());
-                editalAux.setFimSumbissao(edital.getFimSumbissao());
+                editalAux.setInicioSubmissao(edital.getInicioSubmissao());
+                editalAux.setFimSubmissao(edital.getFimSubmissao());
                 editalAux.setInicioAvaliacao(edital.getInicioAvaliacao());
                 editalAux.setFimAvaliacao(edital.getFimAvaliacao());
 
@@ -56,15 +64,27 @@ public class EditalRepository {
             }
         }
     }
-    public static boolean removerEdital(String numero) {
+    public static boolean removerEdital(int numero, int ano) {
         return editais.removeIf(
-                edital -> edital.getNumero().equals(numero)
-        );
+                edital -> edital.getNumero() ==(numero) && edital.getAno() == (ano));
     }
 
     public static List<Edital> listarTodos(){
         return new ArrayList<>(editais); //retornando uma cópia da lista atual de editais
     }
 
+    public static List<Edital> listarPorAno(int ano) {
+
+        List<Edital> resultado = new ArrayList<>();
+
+        for (Edital edital : editais) {
+
+            if (edital.getAno() == ano) {
+                resultado.add(edital);
+            }
+        }
+
+        return resultado;
+    }
 
 }

--- a/src/main/java/br/ifpe/proext/repository/EditalRepository.java
+++ b/src/main/java/br/ifpe/proext/repository/EditalRepository.java
@@ -1,0 +1,70 @@
+package br.ifpe.proext.repository;
+
+import br.ifpe.proext.model.Edital;
+
+
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class EditalRepository {
+
+    private static final List<Edital> editais = new ArrayList<>();
+
+    private EditalRepository(){}
+
+    public static void criarEdital(Edital edital){
+        editais.add(edital);
+    }
+
+    public static Edital buscarPorNumero(String numero){
+        for (Edital edital: editais) {
+            if(edital.getNumero().equals(numero)){
+                return edital;
+            }
+        }
+        return null;
+    }
+
+    public static List<Edital> buscarPorTitulo(String titulo) {
+
+        List<Edital> resultado = new ArrayList<>();
+
+        for (Edital edital : editais) {
+            if (edital.getTitulo().equals(titulo)) {
+                resultado.add(edital);
+            }
+        }
+
+        return resultado;
+    }
+
+    public static void atualizarEdital(Edital edital) {
+
+        for (Edital editalAux : editais) {
+
+            if (editalAux.getNumero().equals(edital.getNumero())) {
+
+                editalAux.setTitulo(edital.getTitulo());
+                editalAux.setData(edital.getData());
+                editalAux.setInicioSumbissao(edital.getInicioSumbissao());
+                editalAux.setFimSumbissao(edital.getFimSumbissao());
+                editalAux.setInicioAvaliacao(edital.getInicioAvaliacao());
+                editalAux.setFimAvaliacao(edital.getFimAvaliacao());
+
+                return;
+            }
+        }
+    }
+    public static boolean removerEdital(String numero) {
+        return editais.removeIf(
+                edital -> edital.getNumero().equals(numero)
+        );
+    }
+
+    public static List<Edital> listarTodos(){
+        return new ArrayList<>(editais); //retornando uma cópia da lista atual de editais
+    }
+
+
+}

--- a/src/main/java/br/ifpe/proext/service/EditalService.java
+++ b/src/main/java/br/ifpe/proext/service/EditalService.java
@@ -1,0 +1,23 @@
+package br.ifpe.proext.service;
+
+
+import br.ifpe.proext.model.Edital;
+import br.ifpe.proext.repository.EditalRepository;
+
+
+public class EditalService {
+
+    private static void definirNovoEdital(Edital edital) {
+
+    }
+
+    public static void cadastrarEdital(Edital edital){
+
+//        validarTitulo(edital.getTitulo());
+//        validarNumero(edital.getNumero());
+
+        definirNovoEdital(edital);
+
+        EditalRepository.criarEdital(edital);
+    }
+}


### PR DESCRIPTION
 Descrição
Este Pull Request implementa a funcionalidade de cadastro de editais (Issue #1). Foi estruturada toda a camada de backend da aplicação seguindo o padrão MVC/Service, preparando o sistema para receber e persistir os dados dos editais.

O que foi feito:
Model (Entidade):Criação da classe Edital com todos os campos obrigatórios para o cadastro:
Título, Número e Ano.
Período de Submissão (Início e Fim).
Período de Avaliação (Início e Fim).
Repository:*Criação do repositório responsável pela comunicação com o banco de dados (Spring Data / JPA) para a entidade `Edital`.
Service:Criação da classe de serviço (`EditalService`) para isolar as regras de negócio do cadastro de editais.
Controller:Implementação do `EditalController` (`ServidorController`) para expor os endpoints que receberão as requisições da interface de usuário.